### PR TITLE
glue-core 1.22.2 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/echo-feedstock/pr1/ec8a538

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/echo-feedstock/pr1/ec8a538

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,90 +1,121 @@
 {% set name = "glue-core" %}
-{% set version = "1.2.4" %}
+{% set version = "1.22.2" %}
 
 package:
-  name: {{ name }}
+  name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  fn: glue-core-{{version}}.tar.gz
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: e8747b5a4f98241d707a5d6ba7498033d0c450130cc1f6074a0cc9ef6de12853
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_')}}-{{ version }}.tar.gz
+  sha256: 2c177daea8b76b62ed9569d146cb8b10bbaaee824944355845270ea6ac1e7b29
 
 build:
   number: 0
-  skip: True  # [ppc64le or py<37]
-  script: python -m pip install --no-deps --ignore-installed .
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   entry_points:
-    - glue = glue.main:main
     - glue-config = glue.config_gen:main
-    - glue-deps = glue._deps:main
-  osx_is_app: True
-  ignore_run_exports:
-    - pyqt
+  skip: True  # [py<310]
 
 requirements:
   host:
     - python
     - pip
-    # We need to include PyQt5 here to make sure that PyQt5 doesn't
-    # get included in install_requires
-    - pyqt >=5.9
     - setuptools_scm
     - setuptools >=30.3.0
     - wheel
   run:
-    # The following is needed to make sure that the package works as a GUI
-    # application (glue needs to be run with python.app, not python)
-    - python.app  # [osx]
-
-    # Required dependencies
     - python
     - numpy >=1.17
-    - matplotlib-base >=3.2
+    - matplotlib >=3.2
     - scipy >=1.1
     - pandas >=1.2
-    - echo >=0.5
+    - echo >=0.6
     - astropy >=4.0
-    - setuptools >=30.3.0
-    - qtpy >=1.9
+    - fast-histogram >=0.12
     - ipython >=4.0
-    - ipykernel >=4.0,!=5.0.0,!=5.1.0
-    - qtconsole >=4.3
     - dill >=0.2
-    - xlrd >=1.2
     - h5py >=2.10
-    - mpl-scatter-density >=0.7
+    - xlrd >=1.2
     - openpyxl >=3.0
-
-    # Optional dependencies (defined in ``extras_require``)
-    - scikit-image
+    - mpl-scatter-density >=0.8
+    - importlib_resources >=1.3  # [py<39]
+    - importlib_metadata >=3.6  # [py<310]
+    - shapely >=2.0
+  run_constrained:
+    # See https://github.com/python-pillow/Pillow/issues/4509
+    # for why we exclude pillow 7.1.0
     - pillow !=7.1.0
-    # Used to export plots to Plot.ly
-    - plotly
 
 test:
-  requires:
-    - pip
   imports:
     - glue
+    - glue._plugin_helpers
+    - glue._settings_helpers
+    - glue.backends
+    - glue.config
     - glue.core
-    - glue.app.qt
+    - glue.core.application_base
+    - glue.core.callback_property
+    - glue.core.command
+    - glue.core.component
+    - glue.core.component_id
+    - glue.core.component_link
+    - glue.core.contracts
+    - glue.core.coordinate_helpers
+    - glue.core.coordinates
+    - glue.core.data
+    - glue.core.data_collection
+    - glue.core.data_combo_helper
+    - glue.core.data_derived
+    - glue.core.data_factories
+    - glue.core.data_factories.fits
+    - glue.core.data_factories.hdf5
+    - glue.core.data_factories.helpers
+    - glue.core.data_factories.pandas
+    - glue.core.data_region
+    - glue.core.decorators
+    - glue.core.edit_subset_mode
+    - glue.core.exceptions
+    - glue.core.fixed_resolution_buffer
+    - glue.core.hub
+    - glue.core.hub_callback_container
+    - glue.core.joins
+    - glue.core.layer_artist
+    - glue.core.link_helpers
+    - glue.core.link_manager
+    - glue.core.message
+    - glue.core.registry
+    - glue.core.roi
+    - glue.core.roi_pretransforms
+    - glue.core.session
+    - glue.core.simpleforms
+    - glue.core.state
+    - glue.core.state_objects
+    - glue.core.subset
+    - glue.core.subset_group
+    - glue.core.tests.test_application_base
+    - glue.core.tests.test_link_helpers
+    - glue.core.tests.test_state
+    - glue.core.units
+    - glue.core.util
+    - glue.core.visual
   commands:
     - pip check
-    - glue --version
-    - glue-deps list
-
-# NOTE: we deliberately do NOT include an app entry here, because we instead do this
-# in the glueviz meta-package (we don't want glue to appear twice in the navigator)
+    - pytest --pyargs glue.tests
+  requires:
+    - pip
+    - pytest
 
 about:
-  home: http://glueviz.org
+  home: https://glueviz.org
+  summary: Multi-dimensional linked data exploration
   license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE
-  summary: Multi-dimensional linked data exploration
+  description: |
+    Glue is a python project to link visualizations of scientific datasets across many files.
   dev_url: https://github.com/glue-viz/glue
-  doc_url: http://docs.glueviz.org/
+  doc_url: https://docs.glueviz.org
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -103,7 +103,6 @@ test:
     - glue.core.visual
   commands:
     - pip check
-    - glue-config --version
     - pytest --pyargs glue.tests
   requires:
     - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,6 +41,8 @@ requirements:
     - importlib_resources >=1.3  # [py<39]
     - importlib_metadata >=3.6  # [py<310]
     - shapely >=2.0
+    # recommended
+    - scikit-image
   run_constrained:
     # See https://github.com/python-pillow/Pillow/issues/4509
     # for why we exclude pillow 7.1.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,7 @@ requirements:
   run:
     - python
     - numpy >=1.17
-    - matplotlib >=3.2
+    - matplotlib-base >=3.2
     - scipy >=1.1
     - pandas >=1.2
     - echo >=0.6
@@ -103,6 +103,7 @@ test:
     - glue.core.visual
   commands:
     - pip check
+    - glue-config --version
     - pytest --pyargs glue.tests
   requires:
     - pip


### PR DESCRIPTION
glue-core 1.22.2 

**Destination channel:** Defaults

### Links

- [PKG-7565]
- dev_url:        https://github.com/glue-viz/glue/tree/v1.22.2
- conda_forge:    https://github.com/conda-forge/glue-core-feedstock
- pypi:           https://pypi.org/project/glue-core/1.22.2
- pypi inspector: https://inspector.pypi.io/project/glue-core/1.22.2

### Explanation of changes:

- new version number


[PKG-7565]: https://anaconda.atlassian.net/browse/PKG-7565?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ